### PR TITLE
fix: Cleanup and possibly blocked popups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # React AppAuth
 ## About
 Opinionated React component (AuthProvider) to provide OpenID Connect and OAuth2 protocol support. Has hooks :tada:
-Heavily inspired by [oidc-react](https://github.com/bjerkio/oidc-react) but without the unmaintained oidc-client-js and redux-oidc.
+Heavily inspired by [oidc-react](https://github.com/bjerkio/oidc-react) but without redux-oidc and the (as of now) unmaintained oidc-client-js.
 
 Based on @openid/appauth-js.
 

--- a/src/AuthInterface.ts
+++ b/src/AuthInterface.ts
@@ -3,10 +3,10 @@ import {
   AuthorizationRequest,
   AuthorizationResponse,
   StringMap,
-} from "@openid/appauth";
-import { Store } from "@reduxjs/toolkit";
-import { AuthAdapter } from "./AuthAdapter";
-import { AuthSlice } from "./AuthSlice";
+} from '@openid/appauth';
+import { Store } from '@reduxjs/toolkit';
+import { AuthAdapter } from './AuthAdapter';
+import { AuthSlice } from './AuthSlice';
 
 export interface AuthContextProps {
   /**
@@ -25,14 +25,6 @@ export interface AuthContextProps {
    *
    */
   signOutRedirect: (args?: AuthProviderSignOutProps) => Promise<void>;
-  //  /**
-  //   * See [UserManager](https://github.com/IdentityModel/oidc-client-js/wiki#usermanager) for more details.
-  //   */
-  //  userManager: UserManager;
-  //  /**
-  //   * See [User](https://github.com/IdentityModel/oidc-client-js/wiki#user) for more details.
-  //   */
-  //  userData?: User | null;
   /**
    * Auth state: True until the library has been initialized.
    */
@@ -196,17 +188,17 @@ export interface AuthProviderSignOutProps {
    * ```
    */
   signoutRedirect?: boolean;
-  redirectUri?: string
+  redirectUri?: string;
 }
 export interface AuthProviderSignInProps {
   timeoutInSeconds?: number;
   redirect_uri?: string;
-  extras?: {response_mode?: string}
+  extras?: { response_mode?: string };
   prompt?: string;
 }
 
 export interface AuthPostMessage {
-  type: "authorization_response"
+  type: 'authorization_response';
   request: AuthorizationRequest;
   response: AuthorizationResponse | null;
   error: AuthorizationError | null;

--- a/src/AuthSlice.ts
+++ b/src/AuthSlice.ts
@@ -72,16 +72,19 @@ export const selectIsLoading = (state: { auth: AuthSlice }): boolean =>
   state.auth.isLoading;
 export const selectIsAuthed = (state: { auth: AuthSlice }): boolean =>
   state.auth.isAuthed;
-export const selectAccessToken = (state: { auth: AuthSlice }): string|undefined =>
-  state.auth.access_token;
-export const selectIdToken = (state: { auth: AuthSlice }): string|undefined =>
+export const selectAccessToken = (state: {
+  auth: AuthSlice;
+}): string | undefined => state.auth.access_token;
+export const selectIdToken = (state: { auth: AuthSlice }): string | undefined =>
   state.auth.id_token;
-export const selectRefreshToken = (state: { auth: AuthSlice }): string|undefined =>
-  state.auth.refresh_token;
-export const selectAccessTokenExpire = (state: { auth: AuthSlice }): UnixTimeStamp|undefined =>
-  state.auth.access_token_expire;
-export const selectRefreshTokenExpire = (state: { auth: AuthSlice }): UnixTimeStamp|undefined =>
-  state.auth.refresh_token_expire;
-
+export const selectRefreshToken = (state: {
+  auth: AuthSlice;
+}): string | undefined => state.auth.refresh_token;
+export const selectAccessTokenExpire = (state: {
+  auth: AuthSlice;
+}): UnixTimeStamp | undefined => state.auth.access_token_expire;
+export const selectRefreshTokenExpire = (state: {
+  auth: AuthSlice;
+}): UnixTimeStamp | undefined => state.auth.refresh_token_expire;
 
 export default authSlice.reducer;

--- a/src/helper/PopupRequestHandler.ts
+++ b/src/helper/PopupRequestHandler.ts
@@ -42,7 +42,7 @@ const AUTHORIZATION_REQUEST_HANDLE_KEY =
   'appauth_current_authorization_request';
 
 interface PopupRequesthandlerParams extends PopupParams {
-  timeoutInSeconds?: number
+  timeoutInSeconds?: number;
 }
 /**
  * Represents an AuthorizationRequestHandler which uses a standard
@@ -130,7 +130,7 @@ export class PopupRequestHandler extends AuthorizationRequestHandler {
             authorizationServiceConfigurationKey(handle),
           ),
         ]).then(() => {
-          return Promise.reject('Failed to create / get popup');
+            return Promise.reject(new Error('Failed to create / get popup'));
         });
       }
     });
@@ -172,7 +172,8 @@ export class PopupRequestHandler extends AuthorizationRequestHandler {
                   if (shouldNotify) {
                     if (error) {
                       // get additional optional info.
-                      const errorUri = queryParams.get('error_uri') || undefined;
+                      const errorUri =
+                        queryParams.get('error_uri') || undefined;
                       const errorDescription =
                         queryParams.get('error_description') || undefined;
                       authorizationError = new AuthorizationError({

--- a/src/helper/PopupRequestHandler.ts
+++ b/src/helper/PopupRequestHandler.ts
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import {
   AuthorizationError,
   AuthorizationRequest,
@@ -77,6 +63,7 @@ export class PopupRequestHandler extends AuthorizationRequestHandler {
     configuration: AuthorizationServiceConfiguration,
     request: AuthorizationRequest,
   ): Promise<AuthorizationRequestResponse> {
+    this._popup = new PopupWindow(this._params);
     const handle = this.crypto.generateRandom(10);
 
     // before you make request, persist all request related data in local storage.
@@ -97,15 +84,32 @@ export class PopupRequestHandler extends AuthorizationRequestHandler {
       ),
     ]);
 
-    return persisted.then(() => {
-      this._popup = new PopupWindow(this._params);
-      if (this._popup) {
-        this._popup.navigate({
-          url: this.buildRequestUrl(configuration, request),
-          id: request.state,
-        });
-        // The Popup notifies the opener and then the WindowPopup promise resolves.
-        return this._popup.promise.then((authorizationResponse) => {
+    return persisted
+      .then(() => {
+        if (this._popup) {
+          this._popup.navigate({
+            url: this.buildRequestUrl(configuration, request),
+            id: request.state,
+          });
+          // The Popup notifies the opener and then the WindowPopup promise resolves.
+          return this._popup.promise.then((authorizationResponse) => {
+            return Promise.all([
+              this.storageBackend.removeItem(AUTHORIZATION_REQUEST_HANDLE_KEY),
+              this.storageBackend.removeItem(authorizationRequestKey(handle)),
+              this.storageBackend.removeItem(
+                authorizationServiceConfigurationKey(handle),
+              ),
+            ]).then(() => {
+              console.log('Delivering authorization response');
+              return {
+                request: request,
+                response: authorizationResponse,
+                error: null,
+              } as AuthorizationRequestResponse;
+            });
+          });
+        } else {
+          // Cleanup
           return Promise.all([
             this.storageBackend.removeItem(AUTHORIZATION_REQUEST_HANDLE_KEY),
             this.storageBackend.removeItem(authorizationRequestKey(handle)),
@@ -113,27 +117,18 @@ export class PopupRequestHandler extends AuthorizationRequestHandler {
               authorizationServiceConfigurationKey(handle),
             ),
           ]).then(() => {
-            console.log('Delivering authorization response');
-            return {
-              request: request,
-              response: authorizationResponse,
-              error: null,
-            } as AuthorizationRequestResponse;
-          });
-        });
-      } else {
-        // Cleanup
-        return Promise.all([
-          this.storageBackend.removeItem(AUTHORIZATION_REQUEST_HANDLE_KEY),
-          this.storageBackend.removeItem(authorizationRequestKey(handle)),
-          this.storageBackend.removeItem(
-            authorizationServiceConfigurationKey(handle),
-          ),
-        ]).then(() => {
             return Promise.reject(new Error('Failed to create / get popup'));
-        });
-      }
-    });
+          });
+        }
+      })
+      .catch(() => {
+        if (this._popup) {
+          this._popup.abort();
+        }
+        return Promise.reject(
+          new Error('Failed to store OIDC request in local-storage'),
+        );
+      });
   }
 
   /**
@@ -149,8 +144,6 @@ export class PopupRequestHandler extends AuthorizationRequestHandler {
           return (
             this.storageBackend
               .getItem(authorizationRequestKey(handle))
-              // requires a corresponding instance of result
-              // TODO(rahulrav@): check for inconsitent state here
               .then((result) => JSON.parse(result!))
               .then((json) => new AuthorizationRequest(json))
               .then((request) => {

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -1,7 +1,7 @@
 export { PopupWindow } from './PopupHelper';
 
 export interface NavigateParams {
-  timeoutInSeconds?: number
+  timeoutInSeconds?: number;
 }
 export interface Navigate {
   navigate(params: NavigateParams): void;


### PR DESCRIPTION
This PR cleans up some parts of the code (removing comments, changing Promise.rejects to Errors).
Also a fix is applied to reduce the chance of blocked popups.

Previously the window.open call was not in the same callstack as the onClick handler as it was executed in a resolved promise.
We now open the popup before we try to store any request in our local storage. When this fails we simply close the window again. This way the window.open call should be in the same callstack as the onClick handler.