### PR TITLE
Fix redirect and implement silent login

### DIFF
--- a/src/AuthCallback.tsx
+++ b/src/AuthCallback.tsx
@@ -1,40 +1,61 @@
-import React, { useEffect } from "react"
-import { useSelector } from "react-redux";
-import { selectIsLoading } from "./AuthSlice";
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { useAuth } from '.';
+import { selectIsLoading } from './AuthSlice';
 
 interface StubHistory {
-  push(uri: string): void
+  push(uri: string): void;
 }
 
 interface AuthCallbackProps {
-  history: StubHistory,
-  default_redirect?: string,
-  isPopup?: boolean
+  history: StubHistory;
+  defaultRedirect?: string;
+  isPopup?: boolean;
+  isSilent?: boolean;
+  onError?: () => React.ReactNode;
 }
 /**
  * Redirects back to a stored uri from localStorage or default if none was found
- * @param AuthCallbackProps 
- * @returns 
+ * @param AuthCallbackProps
+ * @returns
  */
-export const AuthCallback: React.FC<AuthCallbackProps> = ({history, children, default_redirect = '/', isPopup = false}) => {
+export const AuthCallback: React.FC<AuthCallbackProps> = ({
+  history,
+  children,
+  onError,
+  defaultRedirect = '/',
+  isPopup = false,
+  isSilent = false,
+}) => {
   const isLoading = useSelector(selectIsLoading);
-  
+  const auth = useAuth();
+  const [showError, setShowError] = useState<boolean>(false);
+
   // Check if we have something in localStorage redirect to that.
   useEffect(() => {
-    if (!isLoading && !isPopup) {
-      const redirectUri = localStorage.getItem('redirect-uri');
-      if (redirectUri) {
-        localStorage.removeItem('redirect-uri');
-        history.push(redirectUri)
-      } else {
-        history.push(default_redirect)
-      }
+    if (!isLoading) {
+      auth
+        .signinCallback()
+        .then(() => {
+          if (!isPopup && !isSilent) {
+            const redirectUri = localStorage.getItem('redirect-uri');
+            if (redirectUri) {
+              localStorage.removeItem('redirect-uri');
+              history.push(redirectUri);
+            } else {
+              history.push(defaultRedirect);
+            }
+          }
+        })
+        .catch((e) => {
+          console.log(e);
+          setShowError(true);
+        });
     }
   }, [isLoading, isPopup]);
 
-  return (
-    <>
-      {children}
-    </>
-    );
-}
+  if (showError && onError !== undefined) {
+    return <>{onError()}</>;
+  }
+  return <>{children}</>;
+};

--- a/src/AuthInterface.ts
+++ b/src/AuthInterface.ts
@@ -29,6 +29,8 @@ export interface AuthContextProps {
    * Auth state: True until the library has been initialized.
    */
   isLoading: boolean;
+
+  signinCallback: () => Promise<void>;
 }
 
 export interface AuthProviderProps {
@@ -56,6 +58,10 @@ export interface AuthProviderProps {
    * The redirect URI of your client application to receive a response from the OIDC/OAuth2 provider when completing a background sign-in refresh.
    */
   silentRedirectUri?: string;
+  /**
+   * Whether the provider should automatically perform a background sign-in on mount.
+   */
+  silentSignin?: boolean;
   /**
    * A space-delimited list of permissions that the application requires.
    */
@@ -193,8 +199,7 @@ export interface AuthProviderSignOutProps {
 export interface AuthProviderSignInProps {
   timeoutInSeconds?: number;
   redirect_uri?: string;
-  extras?: { response_mode?: string };
-  prompt?: string;
+  extras?: { response_mode?: string; prompt?: string };
 }
 
 export interface AuthPostMessage {

--- a/src/helper/IFrameHelper.ts
+++ b/src/helper/IFrameHelper.ts
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) Brock Allen & Dominick Baier.
+ * Modified by Rudi Floren <r.floren@heinlein-video.de>
+ * Originally licensed under the Apache License, Version 2.0
+ */
+
+import {
+  AuthorizationError,
+  AuthorizationRequest,
+  AuthorizationResponse,
+} from '@openid/appauth';
+import {
+  NavigateParams,
+  Navigate,
+  DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
+} from '.';
+import { AuthPostMessage } from '../AuthInterface';
+
+export interface IFrameParams {
+  id?: string;
+  url?: string;
+  popupClosedTimerInMilliseconds?: number;
+}
+
+interface CustomIFrame extends HTMLIFrameElement {
+  callbacks?: {
+    [index: string]: (
+      request: AuthorizationRequest,
+      response: AuthorizationResponse | null,
+      error: AuthorizationError | null,
+    ) => void;
+  };
+}
+
+/**
+ * A Helper class implementing navigate to open a popup and to notify the parent window via postMessage.
+ */
+export class IFrameWindow implements Navigate {
+  private _promise: Promise<AuthorizationResponse>;
+  private _resolve: (value: AuthorizationResponse) => void = () => {};
+  private _reject: (reason?: Error | AuthorizationError) => void = () => {};
+  private _iframe: CustomIFrame | null;
+  private _timeoutTimer: number | undefined;
+  private _iframeEventListener: ((e: MessageEvent) => void) | undefined;
+
+  constructor(params?: IFrameParams) {
+    this._promise = new Promise((resolve, reject) => {
+      this._resolve = resolve;
+      this._reject = reject;
+    });
+
+    this._iframe = window.document.createElement('iframe');
+
+    // shotgun approach
+    this._iframe.style.visibility = 'hidden';
+    this._iframe.style.position = 'absolute';
+    this._iframe.width = '0px';
+    this._iframe.height = '0px';
+    if (params?.id) {
+      this._iframe.id = params.id;
+    }
+
+    window.document.body.appendChild(this._iframe);
+  }
+
+  get promise(): Promise<AuthorizationResponse> {
+    return this._promise;
+  }
+
+  /**
+   * Navigates the iframe to the url given in Params
+   * @param params NavigateParams & PopupParams
+   * @returns
+   */
+  navigate(
+    params: NavigateParams & IFrameParams,
+  ): Promise<AuthorizationResponse> {
+    if (!this._iframe) {
+      this._reject(
+        new Error('PopupWindow.navigate: Error opening popup window'),
+      );
+    } else if (!params || !params.url) {
+      this._reject(new Error('PopupWindow.navigate: no url provided'));
+      this._reject(new Error('No url provided'));
+    } else {
+      this._timeoutTimer = setTimeout(() => {
+        this.cleanup();
+        this._reject(new Error('IFrame Timeout'));
+      }, (params.timeoutInSeconds || DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS) * 1000);
+
+      this._iframeEventListener = (e: MessageEvent) => {
+        if (!e.data || e.data.type !== 'authorization_response') {
+          return;
+        }
+
+        this.cleanup();
+        if (e.data.response) {
+          return this._resolve(e.data.response);
+        }
+        if (e.data.error) {
+          return this._reject(e.data.error);
+        }
+        return this._reject(
+          new Error('OIDC: Both response and error where empty'),
+        );
+      };
+
+      window.addEventListener('message', this._iframeEventListener);
+
+      this._iframe.contentWindow?.location.replace(params.url);
+    }
+
+    return this.promise;
+  }
+
+  /**
+   * Cleans up timers, handlers and removes the iframe
+   */
+  private cleanup() {
+    if (this._timeoutTimer !== null) {
+      window.clearTimeout(this._timeoutTimer);
+    }
+    this._timeoutTimer = undefined;
+    if (this._iframeEventListener) {
+      window.removeEventListener('message', this._iframeEventListener, false);
+    }
+
+    if (this._iframe) {
+      window.document.body.removeChild(this._iframe);
+    }
+    this._iframe = null;
+  }
+
+  /**
+   * Aborts the current iframe try.
+   */
+  abort(): void {
+    if (this._timeoutTimer !== null) {
+      window.clearTimeout(this._timeoutTimer);
+    }
+    this._timeoutTimer = undefined;
+    if (this._iframeEventListener) {
+      window.removeEventListener('message', this._iframeEventListener, false);
+    }
+
+    if (this._iframe) {
+      window.document.body.removeChild(this._iframe);
+    }
+    this._iframe = null;
+  }
+
+  static notifyOpener(
+    request: AuthorizationRequest,
+    response: AuthorizationResponse | null,
+    error: AuthorizationError | null,
+  ): void {
+    if (window.parent && window != window.parent) {
+      // Send a postMessage with the response to the opening window (only if it was on the same domain)
+      window.parent.postMessage(
+        {
+          type: 'authorization_response',
+          request: request,
+          response: response,
+          error: error,
+        } as AuthPostMessage,
+        window.location.origin,
+      );
+    }
+  }
+}

--- a/src/helper/IFrameRequestHandler.ts
+++ b/src/helper/IFrameRequestHandler.ts
@@ -1,0 +1,215 @@
+import {
+  AuthorizationError,
+  AuthorizationRequest,
+  AuthorizationRequestHandler,
+  AuthorizationRequestResponse,
+  AuthorizationResponse,
+  AuthorizationServiceConfiguration,
+  BasicQueryStringUtils,
+  Crypto,
+  DefaultCrypto,
+  LocalStorageBackend,
+  StorageBackend,
+} from '@openid/appauth';
+import { IFrameParams, IFrameWindow } from './IFrameHelper';
+
+/** key for authorization request. */
+const authorizationRequestKey = (handle: string) => {
+  return `${handle}_appauth_authorization_request`;
+};
+
+/** key for authorization service configuration */
+const authorizationServiceConfigurationKey = (handle: string) => {
+  return `${handle}_appauth_authorization_service_configuration`;
+};
+
+/** key in local storage which represents the current authorization request. */
+const AUTHORIZATION_REQUEST_HANDLE_KEY =
+  'appauth_current_authorization_request';
+
+interface IFrameRequesthandlerParams extends IFrameParams {
+  timeoutInSeconds?: number;
+}
+/**
+ * Represents an AuthorizationRequestHandler which uses a standard
+ * redirect based code flow.
+ */
+export class IFrameRequestHandler extends AuthorizationRequestHandler {
+  private _IFrame: IFrameWindow | undefined;
+  private _params?: IFrameRequesthandlerParams;
+  constructor(
+    // use the provided storage backend
+    // or initialize local storage with the default storage backend which
+    // uses window.localStorage
+    public storageBackend: StorageBackend = new LocalStorageBackend(),
+    utils = new BasicQueryStringUtils(),
+    crypto: Crypto = new DefaultCrypto(),
+  ) {
+    super(utils, crypto);
+  }
+
+  setParams(params: IFrameRequesthandlerParams): void {
+    this._params = params;
+  }
+
+  /**
+   * Creates new IFrame and return a Promise that resolves to AuthorizationRequestResponse.
+   * We can do this, as we do not reload this window.
+   *
+   * @param configuration OIDC config
+   * @param request Auth Request
+   */
+  performAuthorizationRequest(
+    configuration: AuthorizationServiceConfiguration,
+    request: AuthorizationRequest,
+  ): Promise<AuthorizationRequestResponse> {
+    this._IFrame = new IFrameWindow(this._params);
+    const handle = this.crypto.generateRandom(10);
+
+    // before you make request, persist all request related data in local storage.
+    const persisted = Promise.all([
+      this.storageBackend.setItem(AUTHORIZATION_REQUEST_HANDLE_KEY, handle),
+      // Calling toJson() adds in the code & challenge when possible
+      request
+        .toJson()
+        .then((result) =>
+          this.storageBackend.setItem(
+            authorizationRequestKey(handle),
+            JSON.stringify(result),
+          ),
+        ),
+      this.storageBackend.setItem(
+        authorizationServiceConfigurationKey(handle),
+        JSON.stringify(configuration.toJson()),
+      ),
+    ]).catch((e) => {
+      if (this._IFrame) {
+        this._IFrame.abort();
+      }
+      return Promise.reject(
+        new Error(`Failed to store OIDC request in local-storage: ${e}`),
+      );
+    });
+
+    return persisted
+      .then(() => {
+        if (this._IFrame) {
+          this._IFrame.navigate({
+            url: this.buildRequestUrl(configuration, request),
+            id: request.state,
+          });
+          // The IFrame notifies the opener and then the WindowIFrame promise resolves.
+          return this._IFrame.promise
+            .then((authorizationResponse) => {
+              return Promise.all([
+                this.storageBackend.removeItem(
+                  AUTHORIZATION_REQUEST_HANDLE_KEY,
+                ),
+                this.storageBackend.removeItem(authorizationRequestKey(handle)),
+                this.storageBackend.removeItem(
+                  authorizationServiceConfigurationKey(handle),
+                ),
+              ]).then(() => {
+                console.log('Delivering authorization response');
+                return {
+                  request: request,
+                  response: authorizationResponse,
+                  error: null,
+                } as AuthorizationRequestResponse;
+              });
+            })
+            .catch((e) => {
+              if (e.error != undefined) {
+                return Promise.reject(e);
+              } else {
+                return Promise.reject(
+                  new Error(
+                    `Invalid response from completeAuthorizationRequest: ${e.toString()}`,
+                  ),
+                );
+              }
+            });
+        } else {
+          // Cleanup
+          return Promise.all([
+            this.storageBackend.removeItem(AUTHORIZATION_REQUEST_HANDLE_KEY),
+            this.storageBackend.removeItem(authorizationRequestKey(handle)),
+            this.storageBackend.removeItem(
+              authorizationServiceConfigurationKey(handle),
+            ),
+          ]).then(() => {
+            return Promise.reject(new Error('Failed to create / get IFrame'));
+          });
+        }
+      })
+      .catch((e) => {
+        if (this._IFrame) {
+          this._IFrame.abort();
+        }
+        return Promise.reject(e);
+      });
+  }
+
+  /**
+   * Attempts to introspect the contents of storage backend and returns a AuthorizationRequestResponse if the Response is meant for the current request.
+   */
+  protected completeAuthorizationRequest(): Promise<AuthorizationRequestResponse | null> {
+    return this.storageBackend
+      .getItem(AUTHORIZATION_REQUEST_HANDLE_KEY)
+      .then((handle) => {
+        if (handle) {
+          // we have a pending request.
+          // fetch authorization request, and check state
+          return this.storageBackend
+            .getItem(authorizationRequestKey(handle))
+            .then((result) => JSON.parse(result!))
+            .then((json) => new AuthorizationRequest(json))
+            .then((request) => {
+              // check redirect_uri and state
+              const queryParams = new URLSearchParams(
+                window.location.hash.replace('#', '?'),
+              );
+              const state: string | undefined =
+                queryParams.get('state') || undefined;
+              const code: string | undefined =
+                queryParams.get('code') || undefined;
+              const error: string | undefined =
+                queryParams.get('error') || undefined;
+              if (state && (code || error)) {
+                const shouldNotify = state === request.state;
+                let authorizationResponse: AuthorizationResponse | null = null;
+                let authorizationError: AuthorizationError | null = null;
+                if (shouldNotify) {
+                  if (error) {
+                    // get additional optional info.
+                    const errorUri = queryParams.get('error_uri') || undefined;
+                    const errorDescription =
+                      queryParams.get('error_description') || undefined;
+                    authorizationError = new AuthorizationError({
+                      error: error,
+                      error_description: errorDescription,
+                      error_uri: errorUri,
+                      state: state,
+                    });
+                  } else if (code) {
+                    authorizationResponse = new AuthorizationResponse({
+                      code: code,
+                      state: state,
+                    });
+                  }
+
+                  return {
+                    request: request,
+                    response: authorizationResponse,
+                    error: authorizationError,
+                  } as AuthorizationRequestResponse;
+                }
+              }
+              return null;
+            });
+        } else {
+          return null;
+        }
+      });
+  }
+}


### PR DESCRIPTION
This PR changes/adds the following:

- `AuthProvider` now has a signinCallback which actually performs the check if a login flow can be completed.
- `AuthCallback` now uses this signinCallback to correctly complete the login flow when this is shown. This avoid some races.
- `AuthCallback` now has a isSilent property.
- `AuthProvider` now supports the silentSignin to fetch the login state during page load. When set to true, during mount of the `AuthProvider` a iframe will be added to the document, that checks if the current user has any open sessions at the OP.
- The `prompt` property moved from `AuthProviderSignInProps` to `AuthProviderSignInProps.extras`.