### PR TITLE
Fix: silentSign sometimes causes the redirect login to fail

### DIFF
--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -127,7 +127,11 @@ const AuthProviderContext: FC<AuthProviderProps> = ({
   }, [init]);
 
   useEffect(() => {
-    if (silentSignin === true && window.frameElement === null) {
+    if (
+      silentSignin === true &&
+      window.frameElement === null &&
+      !hasCodeInUrl(location)
+    ) {
       dispatch(loading());
       adapter
         .fetchServiceConfiguration()


### PR DESCRIPTION
Sometimes chromes incognito mode would fail to login when a redirect based flow was used.
This seems to be a race condition and is fixed by not trying to silentLogin inside an iFrame or embed.