### PR TITLE
fix: Race condition for the provider methods

### DIFF
--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -207,7 +207,9 @@ const AuthProviderContext: FC<AuthProviderProps> = ({
         value={{
           signinCallback,
           signIn: async (args: AuthProviderSignInProps = {}): Promise<void> => {
-            await adapter.signInRedirect(args);
+            await adapter
+              .maybeFetchServiceConfiguration()
+              .then(() => adapter.signInRedirect(args));
           },
           signInPopup: async (): Promise<void> => {
             await signInPopupHooks();
@@ -216,16 +218,22 @@ const AuthProviderContext: FC<AuthProviderProps> = ({
             args: AuthProviderSignOutProps = {},
           ): Promise<void> => {
             if (args.signoutRedirect) {
-              await adapter.signOutRedirect(args);
+              await adapter
+                .maybeFetchServiceConfiguration()
+                .then(() => adapter.signOutRedirect(args));
             } else {
-              await adapter.signOut();
+              await adapter
+                .maybeFetchServiceConfiguration()
+                .then(() => adapter.signOut());
             }
             await signOutHooks();
           },
           signOutRedirect: async (
             args: AuthProviderSignOutProps = {},
           ): Promise<void> => {
-            await adapter.signOutRedirect(args);
+            await adapter
+              .maybeFetchServiceConfiguration()
+              .then(() => adapter.signOutRedirect(args));
             await signOutHooks();
           },
           isLoading,

--- a/src/AuthSlice.ts
+++ b/src/AuthSlice.ts
@@ -15,6 +15,7 @@ export interface AuthSlice {
   refresh_token_expire?: UnixTimeStamp;
   scope?: string;
   sess_state?: string;
+  silent_renew_error?: string;
 }
 
 export interface IResponse {
@@ -47,7 +48,9 @@ export const authSlice = createSlice({
     loading: (state) => {
       state.isLoading = true;
     },
-    silent_renew_error: (state) => {},
+    silent_renew_error: (state, action: PayloadAction<Error>) => {
+      state.silent_renew_error = action.payload.message;
+    },
     loaded: (state) => {
       state.isLoading = false;
     },


### PR DESCRIPTION
Sometimes the configuration was not fetched when the provider methods
were called. With this PR a Promise is fired before calling the
adpater signin methods that will fetch the configuration if not already
fetched.